### PR TITLE
use to Express v4 Router

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -1,15 +1,14 @@
-module.exports = {
-  bind : function (app) {
+var express = require('express');
+var router = express.Router();
 
-    app.get('/', function (req, res) {
-      res.render('index');
-    });
+router.get('/', function (req, res) {
+  res.render('index');
+});
 
-    app.get('/examples/template-data', function (req, res) {
-      res.render('examples/template-data', { 'name' : 'Foo' });
-    });
+router.get('/examples/template-data', function (req, res) {
+  res.render('examples/template-data', { 'name' : 'Foo' });
+});
 
-    // add your routes here
+// add your routes here
 
-  }
-};
+module.exports = router;

--- a/docs/creating-routes.md
+++ b/docs/creating-routes.md
@@ -27,7 +27,7 @@ Let's break this down into bits:
 
 So as an example, a request for the URL `http://localhost:3000/examples/template-data` has this route:
 
-    get('/examples/template-data', function(req, res) {
+    router.get('/examples/template-data', function(req, res) {
         res.render('examples/template-data', { 'name' : 'Foo' });
     });
     

--- a/server.js
+++ b/server.js
@@ -44,7 +44,13 @@ app.use(function (req, res, next) {
 
 // routes (found in app/routes.js)
 
-routes.bind(app);
+if (typeof(routes) != "function"){
+  console.log(routes.bind);
+  console.log("Warning: the use of bind in routes is deprecated - please check the prototype kit documentation for writing routes.")
+  routes.bind(app);
+} else {
+  app.use("/", routes);
+}
 
 // auto render any view that exists
 


### PR DESCRIPTION
allows the old style `routes.js` but prints a warning in the console:

```Warning: the use of bind in routes is deprecated - please check the prototype kit documentation for writing routes.```